### PR TITLE
Rename pasteurization heating enable signal

### DIFF
--- a/docs/FB_ActuatorManager.txt
+++ b/docs/FB_ActuatorManager.txt
@@ -4,7 +4,7 @@ VAR_INPUT
     Pasteur_CircPump_ON     : BOOL;
     Pasteur_Mixer_ON        : BOOL;
     Pasteur_CoolingValve_ON : BOOL;
-    Pasteur_HeatPowerReq    : REAL;
+    Pasteur_HeatEnable      : BOOL;
 
     // Команды от CIPManager:
     CIP_Valve_Cold_ON  : BOOL;  // холодная вода (CIP)

--- a/docs/FB_Main_PR102.txt
+++ b/docs/FB_Main_PR102.txt
@@ -74,8 +74,8 @@ VAR_INPUT
     AI_TempProduct_x10_UD : UDINT;   // продукт, °C×10 (из АЦП/сети)
     AI_TempJacket_x10_UD  : UDINT;   // рубашка, °C×10 (из АЦП/сети)
 
-    // ===== Из PasteurManager: требование мощности нагрева (PID → %-мощность) =====
-    HeatingPowerReq_IN     : REAL;   // −1.0 = выключить нагрев, иначе 0..300 (% каскад по группам)
+    // ===== Из PasteurManager: разрешение нагрева =====
+    Pasteur_HeatEnable_IN  : BOOL;   // TRUE = разрешить нагрев, FALSE = запретить
 END_VAR
 
 VAR_OUTPUT
@@ -139,10 +139,10 @@ VAR_OUTPUT
     Mode_CIP_Rinse_RunReq  : BOOL; // b12
     CMD_ResetSoftFlow      : BOOL; // b15 — сброс софт-расходомера (зеркало)
 
-    // ===== Выходы для TemperatureManager (RAW + задание мощности) =====
+    // ===== Выходы для TemperatureManager (RAW + разрешение нагрева) =====
     PV_TempProduct_Raw     : REAL;   // °C, из ×10 (валидные)
     PV_TempJacket_Raw      : REAL;   // °C, из ×10 (валидные)
-    HeaterPowerPct_toTemp  : REAL;   // −1.0 вне режима пастеризации, иначе passthrough от HeatingPowerReq_IN
+    Pasteur_HeatEnable     : BOOL;   // → FB_TemperatureManager.Pasteur_HeatEnable
 
     // ===== Для PasteurManager =====
     RecipeMode             : BOOL;   // режим «поэтапный» (из ParMask.b7)
@@ -364,11 +364,11 @@ Mode_CIP_Alk_RunReq   := (ActiveMode_UD = 11) AND reqCIP_Alk;
 Mode_CIP_Acid_RunReq  := (ActiveMode_UD = 12) AND reqCIP_Acid;
 Mode_CIP_Rinse_RunReq := (ActiveMode_UD = 13) AND reqCIP_Rinse;
 
-// ===== Подача %-мощности в TemperatureManager (passthrough) =====
+// ===== Разрешение нагрева для TemperatureManager =====
 IF Mode_Pasteur_RunReq THEN
-    HeaterPowerPct_toTemp := HeatingPowerReq_IN;  // passthrough, REAL
+    Pasteur_HeatEnable := Pasteur_HeatEnable_IN;
 ELSE
-    HeaterPowerPct_toTemp := -1.0;                // выключить нагрев вне режима пастеризации
+    Pasteur_HeatEnable := FALSE; // сброс при останове/смене режима
 END_IF;
 
 // ===== MB_CmdMask2 (542) — ручные DO (1:1 с DO) =====

--- a/docs/FB_PasteurManager.txt
+++ b/docs/FB_PasteurManager.txt
@@ -29,7 +29,7 @@ VAR_OUTPUT
     CircPump_ON       : BOOL;  // → DO2_CircPump
     Mixer_ON          : BOOL;  // → DO3_MixerFwd
     CoolingValve_ON   : BOOL;  // → DO1_ValveCold
-    HeatingPowerReq   : BOOL;  // → FB_TemperatureManager.Pasteur_HeatEnable
+    Pasteur_HeatEnable : BOOL;  // → FB_TemperatureManager.Pasteur_HeatEnable
     HeatTargetTemp    : REAL;  // → FB_TemperatureManager.SP_TempTarget
 
     // Диагностика стадий
@@ -69,7 +69,7 @@ IF NOT init_done THEN
     CircPump_ON := FALSE;
     Mixer_ON := FALSE;
     CoolingValve_ON := FALSE;
-    HeatingPowerReq := FALSE;
+    Pasteur_HeatEnable := FALSE;
     HeatTargetTemp := SP_HeatTemp;
 
     StageMask_Pasteur := 0;
@@ -92,7 +92,7 @@ StageMask_Pasteur := 0;
 HoldElapsed_s := holdSec;
 HoldCompleted := holdDone;
 
-heatEnableState := HeatingPowerReq; // сохранить предыдущее состояние нагрева
+heatEnableState := Pasteur_HeatEnable; // сохранить предыдущее состояние нагрева
 
 // ---------- Общий стоп/сброс ----------
 IF (NOT RunReq) OR CMD_Stop THEN
@@ -264,6 +264,6 @@ END_IF;
 Stage_Current := stage;
 HoldElapsed_s := holdSec;
 HoldCompleted := holdDone;
-HeatingPowerReq := heatEnableState;
+Pasteur_HeatEnable := heatEnableState;
 
 END_FUNCTION_BLOCK

--- a/docs/config/Pasterizator_Стандартные_Переменные.csv
+++ b/docs/config/Pasterizator_Стандартные_Переменные.csv
@@ -184,7 +184,7 @@ CIP_CMD_Mixer_ON;Boolean;No;0;Связь: FB_CIPManager_v2.CIP_Mixer_ON → FB_A
 PAST_CircPump_ON;Boolean;No;0;Команда на циркуляционный насос ПАСТЕРИЗАТОРА.;Ram;PastOut
 PAST_Mixer_ON;Boolean;No;0;Команда на мешалку (прямой ход) от пастеризатора.;Ram;PastOut
 PAST_CoolingValve_ON;Boolean;No;0;Команда на клапан охлаждения рубашки (холодная вода).;Ram;PastOut
-PAST_HeatPowerReq;Boolean;No;0;Разрешение нагрева для блока управления температурой;Ram;PastOut
+PAST_HeatEnable;Boolean;No;0;Разрешение нагрева для блока управления температурой;Ram;PastOut
 PAST_StageMask;Boolean;No;0;Битовая маска этапов пастеризации (для HMI/диагностики), из FB_PasteurManager.StageMask_Pasteur.;Ram;PastOut
 TEMP_DO_Heater1_Cmd;Boolean;No;0;Команда нагрев 1 от TempMgr;Ram;Temp
 TEMP_DO_Heater2_Cmd;Boolean;No;0;Команда нагрев 2 от TempMgr;Ram;Temp


### PR DESCRIPTION
## Summary
- rename the pasteurizer heating request output to Pasteur_HeatEnable across the process blocks
- update FB_Main_PR102 to pass through the boolean enable signal to the temperature manager
- align actuator manager input and configuration tables with the new Pasteur_HeatEnable name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd158bfc4c832988feffb944c9efd6