### PR TITLE
Ensure raw temperature and dosing values use float precision

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ END_VAR;
      PAR_PWM_Period_s, маски CIP) через HMI для запуска режимов.
   5. Проведите проверку CIP и пастеризации с учётом защит: команды CMD_Stop,
      ALM_NoWater, блокировка нагрева при превышении ΔT рубашки.
+  6. В схемах OwenLogic и на HMI назначьте PV_TempProduct_Raw,
+     PV_TempJacket_Raw и SP_DoseVolume типу REAL/Float. Это исключит усечение
+     десятичной части при пересчёте температур и дозы из сетевых регистров.
 *)
 
 END_PROGRAM

--- a/docs/config/Pasterizator_Стандартные_Переменные.csv
+++ b/docs/config/Pasterizator_Стандартные_Переменные.csv
@@ -2,15 +2,15 @@
 Имя переменной;Тип переменной;Энергонезависимость;Значение по умолчанию;Комментарий;Метатип;Путь в каталоге
 PV_TempProduct;Float;No;0;Температура продукта, 0.1 °C (из AI1 NTC);Ram;Process/PV
 PV_TempJacket;Float;No;0;Температура рубашки, 0.1 °C (из AI2 NTC);Ram;Process/PV
-PV_TempProduct_Raw;Boolean;No;0;Температура продукта, 0.1 °C (из TemperMNGR);Ram;Process/PV
-PV_TempJacket_Raw;Boolean;No;0;Температура рубашки, 0.1 °C (из TemperMNGR);Ram;Process/PV
+PV_TempProduct_Raw;Float;No;0;Температура продукта, 0.1 °C (из TemperMNGR);Ram;Process/PV
+PV_TempJacket_Raw;Float;No;0;Температура рубашки, 0.1 °C (из TemperMNGR);Ram;Process/PV
 PAR_UseMixerReverse;Boolean;Yes;0;Разрешить реверс мешалки;Ram;Mixer/Params
 PAR_DispenseEnabled;Boolean;Yes;0;Включить режим розлива;Ram;Dispense/Params
 PAR_DosingEnabled;Boolean;Yes;1;Разрешить порционный розлив;Ram;Dispense/Params
 PAR_PumpFlowRate;Float;Yes;0;Производительность насоса розлива, л/с;Ram;Dispense/Params
 PAR_UsePortionButton;Boolean;No;0;Cтарт порции только по внешней кнопке (b2) ParMask;Ram;Dispense/Params
 PAR_UseGunSensor;Boolean;No;0;Разрешать розлив только при «пистолет на месте (b3) ParMask;Ram;Dispense/Params
-SP_DoseVolume;Boolean;No;0;Объем дозы;Ram;Dispense/Params
+SP_DoseVolume;Float;No;0;Объем дозы;Ram;Dispense/Params
 Dosing_PortionDone;Boolean;No;0;Импульс «Порция готова» от FB_DosingManager;Ram;Dispense/Params
 FillPump_On;Boolean;No;0;Вкл насоса разлива;Ram;Dispense/Params
 CMD_SkipHeatStage;Boolean;No;0;Пропуск этапа нагрева;Ram;Commands


### PR DESCRIPTION
## Summary
- change standard variable definitions so PV_TempProduct_Raw, PV_TempJacket_Raw, and SP_DoseVolume use the Float type
- document that these tags must stay REAL/Float in OwenLogic and HMI to preserve decimal precision

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd15b095408329a9fd637cfa25ca43