### PR TITLE
Add mixer run and heat timeout diagnostics for HMI

### DIFF
--- a/docs/FB_Main_PR102.txt
+++ b/docs/FB_Main_PR102.txt
@@ -6,6 +6,7 @@
   - Конвертация AI (UDINT ×10) → REAL и предварительный контроль обрыва/КЗ делаем в Main,
     на TemperatureManager подаём уже проверенные *_Raw (REAL).
   - Гистерезис больше не формируется в Main — он внутри TemperatureManager.
+  - Формируются статусы STAT_MixerRunning и STAT_HeatTimeout для индикации на HMI.
 *)
 
 FUNCTION_BLOCK FB_Main_PR102
@@ -40,6 +41,7 @@ VAR_INPUT
     SP_SmoothTemp            : REAL;   // °C
     SP_SmoothDiff            : REAL;   // °C
     SP_HoldTime_s            : UDINT;  // сек
+    SP_HeatTime_min          : UDINT;  // мин — лимит на набор температуры (0 = отключено)
 
     // Измерения (фильтрованные от TemperatureManager)
     PV_TempProduct           : REAL;   // °C
@@ -108,6 +110,8 @@ VAR_OUTPUT
     ALM_Mask_UD             : UDINT;
     STAT_OutStateMask       : UDINT;
     MB_OutStateMask         : UDINT;   // 517
+    STAT_MixerRunning       : BOOL;    // TRUE, когда мешалка фактически вращается
+    STAT_HeatTimeout        : BOOL;    // TRUE, если нагрев не уложился в заданное время
 
     // Локальные команды (без сети)
     CMD_Stop                : BOOL;    // аварийный стоп (Variant A: только E-Stop)
@@ -181,6 +185,14 @@ VAR
     pd_expire_sec        : UDINT := 0;
 
     doseR                : REAL := 0.0;
+
+    // Контроль фактического прогрева
+    heatPhaseActive      : BOOL := FALSE;
+    heatPhaseStartSec    : UDINT := 0;
+    heatElapsedSec       : UDINT := 0;
+    heatLimitSec         : UDINT := 0;
+    heatTimeoutActive    : BOOL := FALSE;
+    heatReachedBand      : REAL := 0.3;   // °C — допуск до уставки для сброса тайм-аута
 
     // Импульсообразователь для CMD_Resume
     prevResumeLevel      : BOOL := FALSE;
@@ -299,6 +311,50 @@ doMaskUD.12 := DO13_PumpCIP;
 doMaskUD.13 := DO14_ValveDrain;
 STAT_OutStateMask := doMaskUD;
 MB_OutStateMask   := doMaskUD;
+
+// Фактический статус мешалки: при работе любого направления или ненулевой частоте ПЧ
+STAT_MixerRunning := DO3_MixerFwd OR DO4_MixerRev OR (VFD_RunHz > 0.1);
+
+// Контроль времени набора температуры (в пастеризации)
+IF SP_HeatTime_min = 0 THEN
+    heatLimitSec := 0;
+ELSE
+    IF SP_HeatTime_min >= 71582788 THEN
+        heatLimitSec := 4294967295; // защита от переполнения (UDINT_MAX)
+    ELSE
+        heatLimitSec := SP_HeatTime_min * 60;
+    END_IF;
+END_IF;
+
+IF Mode_Pasteur_RunReq AND (PV_TempProduct < (SP_HeatTemp - heatReachedBand)) THEN
+    IF NOT heatPhaseActive THEN
+        heatPhaseActive   := TRUE;
+        heatPhaseStartSec := Seconds_UD;
+        heatElapsedSec    := 0;
+        heatTimeoutActive := FALSE;
+    ELSE
+        IF Seconds_UD >= heatPhaseStartSec THEN
+            heatElapsedSec := Seconds_UD - heatPhaseStartSec;
+        ELSE
+            heatElapsedSec := 0;
+        END_IF;
+
+        IF (heatLimitSec > 0) AND (heatElapsedSec >= heatLimitSec) THEN
+            heatTimeoutActive := TRUE;
+        END_IF;
+    END_IF;
+ELSE
+    heatPhaseActive := FALSE;
+    heatElapsedSec  := 0;
+
+    IF PV_TempProduct >= (SP_HeatTemp - heatReachedBand) THEN
+        heatTimeoutActive := FALSE;
+    ELSIF NOT Mode_Pasteur_RunReq THEN
+        heatTimeoutActive := FALSE;
+    END_IF;
+END_IF;
+
+STAT_HeatTimeout := heatTimeoutActive;
 
 // ===== РАСПАКОВКА МАСОК КОМАНД (зеркала) =====
 // MB_CmdMask1 (541)

--- a/docs/FB_TemperatureManager.txt
+++ b/docs/FB_TemperatureManager.txt
@@ -9,6 +9,7 @@
   - ШИМ тайм-пропорциональный с периодом PAR_PWM_Period_s (SSR: 1..2 c; контактор: 10..30 c).
   - Фильтрация температур: IIR 1-го порядка (alpha из PAR_FilterAlpha_x1000: 0..1000 → 0..1).
   - Защита по ΔT рубашка–продукт: если превышена SmoothDiffGuard, мощность ограничивается.
+  - При работе в гистерезисе выводит Hyst_HeatRequest для HMI (состояние текущего запроса нагрева).
 *)
 
 FUNCTION_BLOCK FB_TemperatureManager_v3
@@ -68,6 +69,7 @@ VAR_OUTPUT
 
     // Диагностика/индикация:
     DutyPct                   : REAL;       // итоговая мощность после ограничений, %
+    Hyst_HeatRequest          : BOOL;       // TRUE, когда гистерезис требует нагрев (PAR_UsePID = FALSE)
 END_VAR
 
 VAR
@@ -148,6 +150,8 @@ g3Threshold := PAR_G3_StartPct; IF g3Threshold < 0.0 THEN g3Threshold := 0.0; EN
 // ===== ОГРАНИЧЕНИЕ ПО ΔT РУБАШКА–ПРОДУКТ =====
 jacketGuardActive := (PV_TempJacket > (PV_TempProduct + SmoothDiffGuard));
 
+Hyst_HeatRequest := FALSE;
+
 // ===== ОСНОВНОЙ ВЫБОР ТРАКТА (PID / HYST) =====
 IF (NOT Pasteur_HeatEnable) THEN
     // Нагрев запрещён окном стадии — всё в ноль
@@ -221,6 +225,8 @@ ELSE
         ELSE
             dutyPctInternal := 0.0;
         END_IF;
+
+        Hyst_HeatRequest := hystState;
 
         pidIntegral := 0.0;
         prevProductTemp := PV_TempProduct;

--- a/docs/config/Pasterizator_Стандартные_Переменные.csv
+++ b/docs/config/Pasterizator_Стандартные_Переменные.csv
@@ -82,8 +82,8 @@ DO14_ValveDrain;Boolean;No;0;Клапан слив (CIP) / Зуммер;Ram;I/O/
 STAT_AutoActive;Boolean;Yes;0;Признак «был в автоцикле» (для ALM PowerFail);Ram;Status
 STAT_HeatingActive;Boolean;No;0;Есть включённый нагрев;Ram;Status
 STAT_CoolingActive;Boolean;No;0;Охлаждение активно;Ram;Status
-STAT_MixerRunning;Boolean;No;0;Мешалка работает (по факту);Ram;Status
-STAT_HeatTimeout;Boolean;No;0;Истёк лимит времени нагрева (ожидает действия);Ram;Status
+STAT_MixerRunning;Boolean;No;0;Мешалка работает (DO3/DO4 или частота ПЧ >0,1 Гц);Ram;Status
+STAT_HeatTimeout;Boolean;No;0;Нагрев не достиг SP_HeatTemp за SP_HeatTime_min;Ram;Status
 MODE_Current;Long;No;0;Текущий режим: 0=Idle,1=Пастер.,2=Ручной,3=CIP,4=Розлив,5=Рецепт;Ram;Modes
 MODE_PasteurActive;Boolean;No;0;Флаг: пастеризация активна;Ram;Modes
 MODE_ManualActive;Boolean;No;0;Флаг: ручной режим активен;Ram;Modes
@@ -94,7 +94,7 @@ PAR_HeaterGroup2Enabled;Boolean;Yes;1;Вторая группа нагрева �
 PAR_HeaterGroup3Enabled;Boolean;Yes;1;Третья группа нагрева доступна;Ram;Process/Params
 PAR_StoreEnabled;Boolean;Yes;0;Режим хранения после пастеризации;Ram;Process/Params
 Par_UsePid;Boolean;No;0;Использовать ПИД вкл/выкл;Ram;Process/Params
-Hyst_HeatRequest;Boolean;No;0;Флаг нагрева;Ram;Process/Params
+Hyst_HeatRequest;Boolean;No;0;Гистерезис TemperatureManager требует нагрев (без ПИД);Ram;Process/Params
 DI1_MixerFault;Boolean;No;0;Авария мешалки от ПЧ/пускателя (НЗ контакт);Ram;I/O/DI
 DI2_HeaterFault;Boolean;No;0;Авария нагрева (термореле/термостат ТЭНов, НЗ);Ram;I/O/DI
 DI3_LevelJacket;Boolean;No;0;Уровень воды в рубашке (НЗ): 1=уровень есть;Ram;I/O/DI


### PR DESCRIPTION
## Summary
- expose STAT_MixerRunning and STAT_HeatTimeout from FB_Main_PR102, deriving their values from actual mixer outputs and the pasteurization heat timer
- export the hysteresis heat request flag from FB_TemperatureManager so HMI can show binary heating demand
- update the variable catalog descriptions to match the new and adjusted diagnostics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd15c0468c83299b8d4255154649c3